### PR TITLE
Fixed "streams" issue for the type "Instance" (simple-peer V9.11.4)

### DIFF
--- a/types/simple-peer/index.d.ts
+++ b/types/simple-peer/index.d.ts
@@ -241,6 +241,8 @@ declare namespace SimplePeer {
         removeListener(event: "data", listener: (chunk: any) => void): this;
         removeListener(event: "error", listener: (err: Error) => void): this;
         removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+        
+        streams: MediaStream[];
     }
 }
 


### PR DESCRIPTION
Property 'streams' does not exist on type 'Instance'. But each "Peer" should have this property which is not defined.

Adding a new definition:
- [ ] The package does not already provide type for the streams property that exist on an instance of "Peer" object!
